### PR TITLE
Feat get memory map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2024"
 
 [dependencies]
 log = "0.4.22"
-uefi = { version = "0.33.0", features = ["panic_handler", "logger"] }
+uefi = { version = "0.33.0", features = ["panic_handler", "logger", "alloc", "global_allocator"] }

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -ex
+
 # Build EFI image
 cargo build --target x86_64-unknown-uefi
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,65 @@
 #![no_std]
 #![no_main]
 
+extern crate alloc;
+use alloc::format;
+
 use log::info;
+use uefi::mem::memory_map::MemoryMap;
 use uefi::prelude::*;
+use uefi::proto::loaded_image::LoadedImage;
+use uefi::proto::media::file::{Directory, File, FileAttribute, FileHandle, FileMode};
+use uefi::proto::media::fs::SimpleFileSystem;
+
+fn open_root_dir() -> uefi::Result<Directory> {
+    let loaded_image = boot::open_protocol_exclusive::<LoadedImage>(boot::image_handle())?;
+    let device_handle = loaded_image.device().expect("Device handle should exist.");
+    let mut fs = boot::open_protocol_exclusive::<SimpleFileSystem>(device_handle)?;
+    fs.open_volume()
+}
+
+fn save_memory_map(file: FileHandle) -> uefi::Result {
+    let mut file = file.into_regular_file().unwrap();
+
+    // Print header
+    let header = "Index, Type, Type(name), PhysicalStart, NumberOfPages, Attribute\n";
+    file.write(header.as_bytes()).unwrap();
+
+    let memory_map = boot::memory_map(boot::MemoryType::LOADER_DATA)?;
+    for (i, desc) in memory_map.entries().enumerate() {
+        file.write(
+            format!(
+                "{}, {:#x}, {:?}, {:#08x}, {}, {:#x}\n",
+                i,
+                desc.ty.0,
+                desc.ty,
+                desc.phys_start,
+                desc.page_count,
+                desc.att.bits() & 0xfffff,
+            )
+            .as_bytes(),
+        )
+        .unwrap();
+    }
+    Ok(())
+}
 
 #[entry]
 fn main() -> Status {
     uefi::helpers::init().unwrap();
-    info!("Hello, world!");
+    info!("Hello, mikanos-rs!");
+
+    let mut root_dir = open_root_dir().expect("Failed to open root directory.");
+    let memmap_file = root_dir
+        .open(
+            cstr16!("\\memmap"),
+            FileMode::CreateReadWrite,
+            FileAttribute::empty(),
+        )
+        .expect("Failed to open memmap file.");
+    save_memory_map(memmap_file).expect("Failed to save memory map.");
+
+    info!("All done.");
     boot::stall(10_000_000);
     Status::SUCCESS
 }


### PR DESCRIPTION
osbook_day02b相当の内容

- メモリマップを boot service から取得し、`memmap` ファイルに保存する処理を追加
- run.sh の shell option を追加

NOTE:
- format macro は動的メモリ確保を必要とするため、 `uefi` クレートの `alloc` および `global_allocator` feature を利用した。
- Known issue: memmap ファイルが作成されていない または 空 の状態で `run.sh` を実行すると、`memmap` に出力が崩れたエラーメッセージのようなものが書き込まれる。もう一度実行すると、正常な出力に置き換えられる。
  - デバッグがかなり難しそうなので、いったん後回し
  - Ubuntu 24.04 環境でも試してみる